### PR TITLE
add noindex meta tag

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -59,6 +59,7 @@ export default {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      metadata: [{name: 'robots', content: 'noindex'}],
       colorMode: {
         disableSwitch: true,
         respectPrefersColorScheme: true,


### PR DESCRIPTION
This PR adds a `noindex` meta tag to ensure the site is not indexed by search engines while we are between domain names. We'll remove this once we get the site joined up to the correct canonical domain name. This is to avoid penalisation for duplicate content during the transition.