### PR TITLE
Move introduction to docs root

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ sidebar_position: 0
 
 # Introduction
 
-Cucumber is a tool that supports [Behaviour-Driven Development(BDD)](./bdd/index.md).
+Cucumber is a tool that supports [Behaviour-Driven Development (BDD)](./bdd/index.md).
 If you're new to Behaviour-Driven Development read our [BDD introduction](./bdd/index.md)
 first.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,11 @@
 ---
 sidebar_position: 0
-description: "New to Cucumber? Start here!"
 ---
 
 # Introduction
 
-Cucumber is a tool that supports [Behaviour-Driven Development(BDD)](../bdd/index.md).
-If you're new to Behaviour-Driven Development read our [BDD introduction](../bdd/index.md)
+Cucumber is a tool that supports [Behaviour-Driven Development(BDD)](./bdd/index.md).
+If you're new to Behaviour-Driven Development read our [BDD introduction](./bdd/index.md)
 first.
 
 ## What is Cucumber?
@@ -16,7 +15,7 @@ Ok, now that you know that BDD is about discovery, collaboration and examples
 
 Cucumber reads executable specifications written in plain text and validates
 that the software does what those specifications say. The specifications
-consists of multiple *examples*, or *scenarios*. For example:
+consist of multiple *examples*, or *scenarios*. For example:
 
 ```gherkin
 Scenario: Breaker guesses a word
@@ -30,7 +29,7 @@ verifies that the software conforms with the specification and generates a
 report indicating ✅ success or ❌ failure for each scenario.
 
 In order for Cucumber to understand the scenarios, they must follow some basic
-syntax rules, called [Gherkin](../gherkin/index.mdx).
+syntax rules, called [Gherkin](./gherkin/index.mdx).
 
 ## What is Gherkin?
 
@@ -45,17 +44,17 @@ Gherkin serves multiple purposes:
 
 ![Single source of truth](/img/docs/single-source-of-truth.png)
 
-The Cucumber grammar exists in different flavours for many [spoken languages](../gherkin/reference#spoken-languages)
+The Cucumber grammar exists in different flavours for many [spoken languages](./gherkin/reference.md#spoken-languages)
 so that your team can use the keywords in your own language.
 
 Gherkin documents are stored in `.feature` text files and are typically
 versioned in source control alongside the software.
 
-See the [Gherkin reference](../gherkin/reference.mdx) for more details.
+See the [Gherkin reference](./gherkin/reference.md) for more details.
 
 ## What are step definitions?
 
-[Step definitions](../cucumber/step-definitions.mdx) connect Gherkin steps to
+[Step definitions](./cucumber/step-definitions.mdx) connect Gherkin steps to
 programming code. A step definition carries out the action that should be
 performed by the step. So step definitions hard-wire the specification to the
 implementation.
@@ -72,7 +71,8 @@ Step definitions can be written in many programming languages. Here is an exampl
 using JavaScript:
 
 ```javascript
-When("{maker} starts a game", maker => {
-  maker.startGameWithWord({ word: "whale" })
+When('{maker} starts a game', maker => {
+  maker.startGameWithWord({ word: 'whale' })
 })
 ```
+

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,0 @@
----
-sidebar_position: 0
----
-
-# Introduction

--- a/docs/installation/android.md
+++ b/docs/installation/android.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: Java
   status: official

--- a/docs/installation/clojure.md
+++ b/docs/installation/clojure.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: Clojure
   status: unmaintained

--- a/docs/installation/cplusplus.md
+++ b/docs/installation/cplusplus.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: C++
   status: official

--- a/docs/installation/d.md
+++ b/docs/installation/d.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: D
   status: unofficial

--- a/docs/installation/gobdd.md
+++ b/docs/installation/gobdd.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: Go
   status: unofficial

--- a/docs/installation/gocuke.md
+++ b/docs/installation/gocuke.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: Go
   status: semi-official

--- a/docs/installation/golang.md
+++ b/docs/installation/golang.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: Go
   status: official

--- a/docs/installation/gosu.md
+++ b/docs/installation/gosu.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: Gosu
   status: unmaintained

--- a/docs/installation/groovy.md
+++ b/docs/installation/groovy.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: Groovy
   status: unmaintained

--- a/docs/installation/index.mdx
+++ b/docs/installation/index.mdx
@@ -1,6 +1,6 @@
 ---
 hide_table_of_contents: true
-pagination_next: cucumber/index
+pagination_next: guides/index
 ---
 
 import {Implementations, StatusBadge} from '@site/src/components/Installation';

--- a/docs/installation/ios.md
+++ b/docs/installation/ios.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: iOS (Swift/ObjC)
   status: semi-official

--- a/docs/installation/java.md
+++ b/docs/installation/java.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   bigThree: true
   language: Java

--- a/docs/installation/javascript.md
+++ b/docs/installation/javascript.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   bigThree: true
   language: JavaScript

--- a/docs/installation/jruby.md
+++ b/docs/installation/jruby.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: JRuby
   status: unmaintained

--- a/docs/installation/jython.md
+++ b/docs/installation/jython.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: Jython
   status: unmaintained

--- a/docs/installation/kotlin.md
+++ b/docs/installation/kotlin.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: Kotlin
   status: official

--- a/docs/installation/lua.md
+++ b/docs/installation/lua.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: Lua
   status: official

--- a/docs/installation/ocaml.md
+++ b/docs/installation/ocaml.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: OCaml
   status: official

--- a/docs/installation/perl.md
+++ b/docs/installation/perl.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: Perl
   status: semi-official

--- a/docs/installation/php.md
+++ b/docs/installation/php.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: PHP
   status: semi-official

--- a/docs/installation/python.md
+++ b/docs/installation/python.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: Python
   status: semi-official

--- a/docs/installation/ruby.md
+++ b/docs/installation/ruby.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   bigThree: true
   language: Ruby

--- a/docs/installation/rust.md
+++ b/docs/installation/rust.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: Rust
   status: unofficial

--- a/docs/installation/scala.md
+++ b/docs/installation/scala.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: Scala
   status: official

--- a/docs/installation/specflow.md
+++ b/docs/installation/specflow.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: .NET (C#, F#, VB)
   status: semi-official

--- a/docs/installation/tcl.md
+++ b/docs/installation/tcl.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: Tcl
   status: unmaintained

--- a/docs/installation/xunit-gherkin-quick.md
+++ b/docs/installation/xunit-gherkin-quick.md
@@ -1,6 +1,6 @@
 ---
 pagination_prev: installation/index
-pagination_next: cucumber/index
+pagination_next: guides/index
 sidebar_custom_props:
   language: .NET (C#, F#, VB)
   status: semi-official

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -74,7 +74,7 @@ export default {
     {
       metadata: [{ name: 'robots', content: 'noindex' }],
       colorMode: {
-        // disableSwitch: true,
+        disableSwitch: true,
         respectPrefersColorScheme: true,
       },
       image: 'img/logo.svg',

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -4,7 +4,13 @@ import YAML from 'yaml'
 import { readFileSync } from 'node:fs'
 
 const lightCodeTheme = themes.jettwaveLight
-const darkCodeTheme = themes.jettwaveDark
+const darkCodeTheme = {
+  ...themes.jettwaveDark,
+  plain: {
+    ...themes.jettwaveDark.plain,
+    backgroundColor: 'var(--ifm-navbar-background-color)'
+  }
+}
 
 export default {
   title: 'Cucumber',
@@ -68,7 +74,7 @@ export default {
     {
       metadata: [{ name: 'robots', content: 'noindex' }],
       colorMode: {
-        disableSwitch: true,
+        // disableSwitch: true,
         respectPrefersColorScheme: true,
       },
       image: 'img/logo.svg',

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -8,8 +8,8 @@ const darkCodeTheme = {
   ...themes.jettwaveDark,
   plain: {
     ...themes.jettwaveDark.plain,
-    backgroundColor: 'var(--ifm-navbar-background-color)'
-  }
+    backgroundColor: 'var(--ifm-navbar-background-color)',
+  },
 }
 
 export default {

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -11,7 +11,7 @@ export default {
   tagline: 'lets you write automated tests in plain language',
   favicon: 'img/logo.svg',
   stylesheets: [
-    '//fonts.googleapis.com/css2?family=Inconsolata&family=Lato:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap',
+    '//fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Lato:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap',
   ],
 
   url: 'https://cucumber.community',

--- a/netlify.toml
+++ b/netlify.toml
@@ -70,6 +70,10 @@
 
 # Relocated docs
 [[redirects]]
+  from = "/docs/guides/overview"
+  to = "/docs"
+  status = 301
+[[redirects]]
   from = "/docs/community/get-in-touch"
   to = "/docs/community"
   status = 301

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -15,7 +15,7 @@
 }
 
 [data-theme='dark'] {
-  --ifm-footer-background-color: #282a36;
+  --ifm-footer-background-color: var(--ifm-navbar-background-color);
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
 

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -10,7 +10,7 @@
   --ifm-footer-background-color: #f6f8fa;
   --ifm-code-font-size: 100%;
   --ifm-font-family-base: 'Lato', sans-serif;
-  --ifm-font-family-monospace: 'Inconsolata', monospace;
+  --ifm-font-family-monospace: 'JetBrains Mono', monospace;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 


### PR DESCRIPTION
This PR moves the introduction/overview out of the guides section (with a redirect for the old path) to be the content served for `/docs` - this makes more sense than "Installation" being the first doc you see.

It also fixes some visual issues with the dark theme and code blocks.