### PR TITLE
Various redirects and aliases

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -118,6 +118,14 @@
   to = "/docs/contributing"
   status = 301
 [[redirects]]
+  from = "/tools/cucumber-open/contribute"
+  to = "/docs/contributing"
+  status = 301
+[[redirects]]
+  from = "/contribute"
+  to = "/docs/contributing"
+  status = 301
+[[redirects]]
   from = "/docs/community/contributing-to-documentation"
   to = "https://github.com/cucumber/website/blob/main/CONTRIBUTING.md"
   status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -104,14 +104,24 @@
   to = "/blog"
   status = 301
 
+# Community aliases
+[[redirects]]
+  from = "/docs/community/get-in-touch"
+  to = "/docs/community"
+  status = 301
+[[redirects]]
+  from = "/support"
+  to = "/community"
+  status = 301
+[[redirects]]
+  from = "/contact-us"
+  to = "/community"
+  status = 301
+
 # Relocated docs
 [[redirects]]
   from = "/docs/guides/overview"
   to = "/docs"
-  status = 301
-[[redirects]]
-  from = "/docs/community/get-in-touch"
-  to = "/docs/community"
   status = 301
 [[redirects]]
   from = "/docs/community/contributing"

--- a/netlify.toml
+++ b/netlify.toml
@@ -37,6 +37,14 @@
   from = "/conduct"
   to = "https://github.com/cucumber/.github/tree/main?tab=coc-ov-file"
   status = 302
+[[redirects]]
+  from = "/school"
+  to = "https://school.cucumber.io"
+  status = 301
+[[redirects]]
+  from = "/school/*"
+  to = "https://school.cucumber.io"
+  status = 301
 
 # Blog posts with parens in the slug
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -118,6 +118,20 @@
   to = "/community"
   status = 301
 
+# Events aliases
+[[redirects]]
+  from = "/resources/events"
+  to = "/events"
+  status = 301
+[[redirects]]
+  from = "/speakers"
+  to = "/events"
+  status = 301
+[[redirects]]
+  from = "/cukenfest"
+  to = "/events"
+  status = 301
+
 # Relocated docs
 [[redirects]]
   from = "/docs/guides/overview"

--- a/netlify.toml
+++ b/netlify.toml
@@ -76,6 +76,34 @@
   to = "/blog/bdd/keep-your-scenarios-brief"
   status = 301
 
+# Blog tags
+[[redirects]]
+  from = "/blog/news"
+  to = "/blog"
+  status = 301
+[[redirects]]
+  from = "/blog/bdd"
+  to = "/blog/tags/bdd"
+  status = 301
+[[redirects]]
+  from = "/blog/bdd/*"
+  to = "/blog/tags/bdd"
+  status = 301
+[[redirects]]
+  from = "/blog/open-source"
+  to = "/blog/tags/open-source"
+  status = 301
+[[redirects]]
+  from = "/blog/open-source/*"
+  to = "/blog/tags/open-source"
+  status = 301
+
+# Blog catch-all fallback
+[[redirects]]
+  from = "/blog/*"
+  to = "/blog"
+  status = 301
+
 # Relocated docs
 [[redirects]]
   from = "/docs/guides/overview"

--- a/netlify.toml
+++ b/netlify.toml
@@ -117,6 +117,10 @@
   from = "/contact-us"
   to = "/community"
   status = 301
+[[redirects]]
+  from = "/team"
+  to = "/community"
+  status = 302
 
 # Events aliases
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -86,22 +86,8 @@
   to = "/blog/tags/bdd"
   status = 301
 [[redirects]]
-  from = "/blog/bdd/*"
-  to = "/blog/tags/bdd"
-  status = 301
-[[redirects]]
   from = "/blog/open-source"
   to = "/blog/tags/open-source"
-  status = 301
-[[redirects]]
-  from = "/blog/open-source/*"
-  to = "/blog/tags/open-source"
-  status = 301
-
-# Blog catch-all fallback
-[[redirects]]
-  from = "/blog/*"
-  to = "/blog"
   status = 301
 
 # Community aliases

--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -1,0 +1,20 @@
+import { Subscribe } from '@site/src/components/Newsletter'
+import React from 'react'
+import Layout from '@theme/Layout'
+
+export default function Events() {
+  return (
+    <Layout>
+      <main>
+        <div className="container readable-blurb text--center padding-vert--lg">
+          <h1>Events</h1>
+          <p>
+            We don't currently have any Cucumber events lined up. If/when that changes, newsletter
+            subscribers will be among the first to know.
+          </p>
+          <Subscribe />
+        </div>
+      </main>
+    </Layout>
+  )
+}

--- a/src/theme/NotFound/Content/index.tsx
+++ b/src/theme/NotFound/Content/index.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react'
+import Link from '@docusaurus/Link'
+
+export default function NotFoundContent(): ReactNode {
+  return (
+    <main>
+      <div className="container readable-blurb text--center padding-vert--lg">
+        <h1>Not found</h1>
+        <p>There's nothing at this path. Sorry about that.</p>
+        <Link className="button button--secondary" to="/">
+          Start Again
+        </Link>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
This PR adds various redirect rules to deal as gracefully as possible with paths that existed on the old site but don't on this one.

It also adds a brief page at `/events` as a catch-all for `/cukenfest` and other event-related paths, with a newsletter CTA.

And the 404 content is customised, with a link back to the homepage.