### PR TITLE
Add Google Analytics

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -68,6 +68,10 @@ export default {
         theme: {
           customCss: require.resolve('./src/css/custom.scss'),
         },
+        gtag: {
+          trackingID: 'G-YY58V5DFE7',
+          anonymizeIP: true,
+        },
       },
     ],
   ],


### PR DESCRIPTION
Using the Docusaurus preset per https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag