### PR TITLE
Enable sitemap plugin

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -72,7 +72,10 @@ export default {
           trackingID: 'G-YY58V5DFE7',
           anonymizeIP: true,
         },
-        sitemap: {},
+        sitemap: {
+          lastmod: 'datetime',
+          changefreq: 'weekly',
+        },
       },
     ],
   ],

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -72,6 +72,7 @@ export default {
           trackingID: 'G-YY58V5DFE7',
           anonymizeIP: true,
         },
+        sitemap: {},
       },
     ],
   ],


### PR DESCRIPTION
This PR enables the Docusaurus sitemap plugin per https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-sitemap, which will help crawlers.

This will not actually take effect until we re-enable robots in #50.