### PR TITLE
Support version shortcodes

### DIFF
--- a/docs/guides/10-minute-tutorial.mdx
+++ b/docs/guides/10-minute-tutorial.mdx
@@ -82,7 +82,7 @@ Before we begin, you'll need the following:
     mvn archetype:generate                     \
     "-DarchetypeGroupId=io.cucumber"           \
     "-DarchetypeArtifactId=cucumber-archetype" \
-    "-DarchetypeVersion=7.20.1"                \
+    "-DarchetypeVersion={{% version "cucumberjvm" %}}                 \
     "-DgroupId=hellocucumber"                  \
     "-DartifactId=hellocucumber"               \
     "-Dpackage=hellocucumber"                  \
@@ -313,7 +313,7 @@ Before we begin, you'll need the following:
         "author": "",
         "license": "ISC",
         "devDependencies": {
-            "@cucumber/cucumber": "^11.1.1"
+            "@cucumber/cucumber": "^{{% version "cucumberjs" %}}"
         }
     }
     ```
@@ -360,8 +360,8 @@ Before we begin, you'll need the following:
     source "https://rubygems.org"
 
     group :test do
-        gem 'cucumber', '~> 9.2.0'
-        gem 'rspec', '~> 3.13.0'
+        gem 'cucumber', '~> {{% version "cucumberruby" %}}'
+        gem 'rspec', '~> {{% version "rspec" %}}'
     end
     ```
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -15,6 +15,8 @@ const darkCodeTheme = {
 
 const platformsCount = globbySync('docs/installation/*.md').length
 
+const versions = YAML.parse(readFileSync('./versions.yaml', { encoding: 'utf-8' }))
+
 export default {
   title: 'Cucumber',
   tagline: 'lets you write automated tests in plain language',
@@ -49,6 +51,21 @@ export default {
           showLastUpdateTime: true,
           remarkPlugins: [
             [require('@docusaurus/remark-plugin-npm2yarn'), { sync: true, converters: ['yarn'] }],
+          ],
+          rehypePlugins: [
+            [
+              require('rehype-rewrite'),
+              {
+                rewrite: (node) => {
+                  if (node.type == 'text') {
+                    node.value = node.value?.replaceAll(
+                      /{{% ?version "(\w+)" ?%}}/g,
+                      (match, name) => versions[name]
+                    )
+                  }
+                },
+              },
+            ],
           ],
         },
         blog: {
@@ -151,6 +168,6 @@ export default {
   plugins: ['docusaurus-plugin-sass'],
   customFields: {
     platformsCount,
-    versions: YAML.parse(readFileSync('./versions.yaml', { encoding: 'utf-8' })),
+    versions,
   },
 } satisfies Config

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@types/lodash.sortby": "^4.7.9",
         "globby": "^14.0.2",
         "prettier": "^3.4.2",
+        "rehype-rewrite": "^4.0.2",
         "yaml": "^2.6.1"
       },
       "engines": {
@@ -5294,6 +5295,17 @@
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw=="
     },
+    "node_modules/bcp-47-match": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
+      "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -6433,6 +6445,23 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-selector-parser": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.0.5.tgz",
+      "integrity": "sha512-3itoDFbKUNx1eKmVpYMFyqKX04Ww9osZ+dLgrk6GEv6KMVeXUhUnp4I5X+evw+u3ZxVU6RFXSSRxlTeMh8bA+g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/css-tree": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
@@ -6886,6 +6915,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/direction": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-2.0.1.tgz",
+      "integrity": "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "direction": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dns-packet": {
@@ -8313,6 +8356,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-has-property": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-parse-selector": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
@@ -8342,6 +8399,34 @@
         "unist-util-visit": "^5.0.0",
         "vfile": "^6.0.0",
         "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-select": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-6.0.3.tgz",
+      "integrity": "sha512-OVRQlQ1XuuLP8aFVLYmC2atrfWHS5UD3shonxpnyrjcCkwtvmt/+N6kYJdcY4mkMJhxp4kj2EFIxQ9kvkkt/eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "bcp-47-match": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "css-selector-parser": "^3.0.0",
+        "devlop": "^1.0.0",
+        "direction": "^2.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "nth-check": "^2.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
         "zwitch": "^2.0.0"
       },
       "funding": {
@@ -8427,6 +8512,20 @@
         "space-separated-tokens": "^2.0.0",
         "web-namespaces": "^2.0.0",
         "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -14529,6 +14628,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-rewrite": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-rewrite/-/rehype-rewrite-4.0.2.tgz",
+      "integrity": "sha512-rjLJ3z6fIV11phwCqHp/KRo8xuUCO8o9bFJCNw5o6O2wlLk6g8r323aRswdGBQwfXPFYeSuZdAjp4tzo6RGqEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hast-util-select": "^6.0.0",
+        "unified": "^11.0.3",
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
       }
     },
     "node_modules/relateurl": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
     "@docusaurus/types": "^3.1.1",
     "@tsconfig/docusaurus": "2.0.3",
     "@types/lodash.sortby": "^4.7.9",
-    "prettier": "^3.4.2",
     "globby": "^14.0.2",
+    "prettier": "^3.4.2",
+    "rehype-rewrite": "^4.0.2",
     "yaml": "^2.6.1"
   },
   "browserslist": {


### PR DESCRIPTION
For polyglot text we added the `<Term/>` component for use in MDX, which is the paved-road way to do that in Docusaurus.

This approach falls down with the "version" shortcodes - where we have a Renovate-managed file of latest versions and swap them into docs - because they tend to be needed in code fences, and you can't use MDX components there.

This PR adds a rehype plugin to find-and-replace shortcodes as part of the Markdown -> HTML processing pipeline. It's not pretty, but it does work.