### PR TITLE
Swap Specflow for Reqnroll in installation docs

### DIFF
--- a/docs/installation/reqnroll.md
+++ b/docs/installation/reqnroll.md
@@ -7,6 +7,8 @@ sidebar_custom_props:
   icon: dotnet.svg
 ---
 
-# SpecFlow
+# Reqnroll
 
-Please see the [SpecFlow website](https://specflow.org/).
+Please see the [Reqnroll website](https://reqnroll.net/).
+
+(Reqnroll is a reboot of the now-retired SpecFlow project.)

--- a/netlify.toml
+++ b/netlify.toml
@@ -102,6 +102,10 @@
 
 # Relocated docs
 [[redirects]]
+  from = "/docs/installation/specflow"
+  to = "/docs/installation/reqnroll"
+  status = 301
+[[redirects]]
   from = "/docs/guides/overview"
   to = "/docs"
   status = 301


### PR DESCRIPTION
### 🤔 What's changed?

Replace the SpecFlow page in the docs with Reqnroll, redirect from the old path.

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)