### PR TITLE
Fixed missing backticks

### DIFF
--- a/docs/guides/10-minute-tutorial.mdx
+++ b/docs/guides/10-minute-tutorial.mdx
@@ -607,9 +607,9 @@ public void i_should_be_told(String string) {
 
 Copy each of the three snippets for the undefined steps and paste them into
 <Content lang="java">`src/test/java/hellocucumber/StepDefinitions.java`</Content>
-<Content lang="kotlin">`src/test/kotlin/hellocucumber/Stepdefs.kt</Content>
+<Content lang="kotlin">`src/test/kotlin/hellocucumber/Stepdefs.kt`</Content>
 <Content lang="javascript">`features/step_definitions/stepdefs.js`</Content>
-<Content lang="ruby">`features/step_definitions/stepdefs.rb</Content>.
+<Content lang="ruby">`features/step_definitions/stepdefs.rb`</Content>.
 
 <Content lang="kotlin">
     Unfortunately, Cucumber does not generate snippets in Kotlin. But fortunately IDEA can convert the Java code to Kotlin code for you. You might need to improve the translated code, to make it more idiomatic.


### PR DESCRIPTION
Updated documentation code, the closing backticks were missing, leading to missing text.