### PR TITLE
Add Cucumber for VSCode

### DIFF
--- a/docs/tools/index.mdx
+++ b/docs/tools/index.mdx
@@ -27,7 +27,9 @@ See the [`Cucumber.tmbundle`](https://github.com/cucumber/cucumber-tmbundle) doc
 
 [Visual Studio Code](https://code.visualstudio.com/) is a code editor for Windows, Linux, or macOS.
 
-You can use it with a [Cucumber (Gherkin) plugin](https://marketplace.visualstudio.com/items?itemName=alexkrechik.cucumberautocomplete).
+You can use it with these extensions:
+ * [Cucumber for VSCode](https://marketplace.visualstudio.com/items?itemName=CucumberOpen.cucumber-official) by the Cucumber Team ([maintainers wanted](https://github.com/cucumber/vscode/issues/205)!)
+ * [Cucumber (Gherkin) Full Support](https://marketplace.visualstudio.com/items?itemName=alexkrechik.cucumberautocomplete) by Alexander Krechik.
 
 ### Nova
 


### PR DESCRIPTION
### ⚡️ What's your motivation? 
While the documentation mentioned the existence of VS Code, it didn't include the Cucumber for VSCode extension. A bit of an oversight.

Originally pointed out by dheerajramchandani in https://github.com/cucumber/common/discussions/2266

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)
