### PR TITLE
Fix layout issue when no sidebar

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -118,7 +118,7 @@ adjusting for padding. This matches what the blog and our custom page layouts al
   }
 
   [class^='docsWrapper'] {
-    max-width: var(--ifm-container-width);
+    width: min(var(--ifm-container-width), 100%);
     margin-left: auto;
     margin-right: auto;
   }
@@ -133,7 +133,7 @@ At the wider breakpoint for the Infima container, re-declare the widths.
   }
 
   [class^='docsWrapper'] {
-    max-width: var(--ifm-container-width-xl);
+    width: min(var(--ifm-container-width-xl), 100%);
   }
 }
 


### PR DESCRIPTION
### 🤔 What's changed?

This PR changes the custom CSS to ensure the docs layout always matches the width of the nav bar and doesn't compress itself when there's no right sidebar due to no table of contents.

### ⚡️ What's your motivation? 

Fixes #131.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)


### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
