### PR TITLE
Pin actions to exact version numbers

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -12,8 +12,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 22.x
       - run: npm ci


### PR DESCRIPTION
With renovate automatically updating versions we can use exact version numbers alongside pinned hashes. This ensures that renovate will quietly merge minor and patch versions, creating pull requests for major versions and hopefully never notify us about digest changes.
