### PR TITLE
Setup Zizmor analysis for Github Actions

### DIFF
--- a/.github/workflows/zizmor-analysis.yaml
+++ b/.github/workflows/zizmor-analysis.yaml
@@ -1,0 +1,30 @@
+name: GitHub Actions Security Analysis
+
+on:
+  push:
+    branches:
+      - main
+      - 'releases/**'
+    paths:
+      - '.github/**'
+  pull_request:
+    paths:
+      - '.github/**'
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run Zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+


### PR DESCRIPTION
### ⚡️ What's your motivation? 

GitHub Actions come with a non-trivial number of settings that are not secure by default. Zizmor can scan these and report them as Code scanning finding in GitHub. This enables us to solve these issues in a structured manner.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
