### PR TITLE
Remove Google Analytics config

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -101,10 +101,6 @@ export default {
         theme: {
           customCss: './src/css/custom.scss',
         },
-        gtag: {
-          trackingID: 'G-YY58V5DFE7',
-          anonymizeIP: true,
-        },
         sitemap: {
           lastmod: 'datetime',
           changefreq: 'weekly',


### PR DESCRIPTION
### 🤔 What's changed?

We have server-side analytics available now (courtesy of Netlify) so we can remove the dependency on Google Analytics - and its tracking cookies.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
