### PR TITLE
Prefer `cucumber-jakarta-openejb` to `cucumber-openejb`

### DIFF
--- a/docs/cucumber/state.mdx
+++ b/docs/cucumber/state.mdx
@@ -219,7 +219,7 @@ To use OpenEJB, add the following dependency to your `pom.xml`:
 ```xml
 <dependency>
     <groupId>io.cucumber</groupId>
-    <artifactId>cucumber-openejb</artifactId>
+    <artifactId>cucumber-jakarta-openejb</artifactId>
     <version>{{% version "cucumberjvm" %}}</version>
     <scope>test</scope>
 </dependency>
@@ -228,10 +228,10 @@ To use OpenEJB, add the following dependency to your `pom.xml`:
 Or, if you are using Gradle, add:
 
 ```kotlin
-testImplementation("io.cucumber:cucumber-openejb:{{% version "cucumberjvm" %}}")
+testImplementation("io.cucumber:cucumber-jakarta-openejb:{{% version "cucumberjvm" %}}")
 ```
 
-There is no documentation yet, but the code is on [GitHub](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-openejb).
+There is no documentation yet, but the code is on [GitHub](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-jakarta-openejb).
 
 ### Weld
 


### PR DESCRIPTION
### ⚡️ What's your motivation? 

OpenEJB v8 can not be used on Java 24+ due to the removal of the security manager. As a consequence neither can `cucumber-openejb`. Users should upgrade to OpenEJB v9 and switch to `cucumber-jakarta-openejb`.
### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)


### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
