### PR TITLE
Remove `cucumber-needle`

### DIFF
--- a/docs/cucumber/state.mdx
+++ b/docs/cucumber/state.mdx
@@ -254,28 +254,6 @@ testImplementation("io.cucumber:cucumber-weld:{{% version "cucumberjvm" %}}")
 
 There is no documentation yet, but the code is on [GitHub](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-weld).
 
-### Needle
-
-To use Needle, add the following dependency to your `pom.xml`:
-
-```xml
-<dependency>
-    <groupId>io.cucumber</groupId>
-    <artifactId>cucumber-needle</artifactId>
-    <version>{{% version "cucumberjvm" %}}</version>
-    <scope>test</scope>
-</dependency>
-```
-
-Or, if you are using Gradle, add:
-
-```kotlin
-testImplementation("io.cucumber:cucumber-needle:{{% version "cucumberjvm" %}}")
-```
-
-There is no documentation yet, but the code is on [GitHub](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-needle).
-
-
 ### Quarkus
 
 To use Quarkus, add the following dependency to your `pom.xml`:


### PR DESCRIPTION
### ⚡️ What's your motivation? 

Cucumber Needle was removed from `cucumber-jvm` in v7. It doesn't have to be documented anymore.

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)


### 📋 Checklist:



- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)