### PR TITLE
Prefer `cucumber-jakarta-cdi` to `cucumber-weld`

### DIFF
--- a/docs/cucumber/state.mdx
+++ b/docs/cucumber/state.mdx
@@ -233,14 +233,14 @@ testImplementation("io.cucumber:cucumber-jakarta-openejb:{{% version "cucumberjv
 
 There is no documentation yet, but the code is on [GitHub](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-jakarta-openejb).
 
-### Weld
+### CDI
 
-To use Weld, add the following dependency to your `pom.xml`:
+To use CDI, add the following dependency to your `pom.xml`:
 
 ```xml
 <dependency>
     <groupId>io.cucumber</groupId>
-    <artifactId>cucumber-weld</artifactId>
+    <artifactId>cucumber-jakarta-cdi</artifactId>
     <version>{{% version "cucumberjvm" %}}</version>
     <scope>test</scope>
 </dependency>
@@ -249,10 +249,10 @@ To use Weld, add the following dependency to your `pom.xml`:
 Or, if you are using Gradle, add:
 
 ```kotlin
-testImplementation("io.cucumber:cucumber-weld:{{% version "cucumberjvm" %}}")
+testImplementation("io.cucumber:cucumber-jakarta-cdi:{{% version "cucumberjvm" %}}")
 ```
 
-There is no documentation yet, but the code is on [GitHub](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-weld).
+There is no documentation yet, but the code is on [GitHub](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-jakarta-cdi).
 
 ### Needle
 


### PR DESCRIPTION
### ⚡️ What's your motivation? 

`cucumber-weld` was removed from `cucumber-jvm` in v7. It doesn't have to be documented anymore.

### 🏷️ What kind of change is this?
- :book: Documentation (improvements without changing code)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
