### PR TITLE
Document support for scientific notation floats

### DIFF
--- a/docs/cucumber/cucumber-expressions.mdx
+++ b/docs/cucumber/cucumber-expressions.mdx
@@ -75,7 +75,7 @@ the following built-in parameter types:
 | `{short}`       | Matches the same as `{int}`, but converts to a 16 bit signed integer if the platform supports it. |
 | `{long}`        | Matches the same as `{int}`, but converts to a 64 bit signed integer if the platform supports it. |
 
-+### Scientific notation
+### Scientific notation
 
 `{float}`, `{double}` and `{bigdecimal}` also match numbers written in scientific
 notation, using an uppercase `E` to separate the mantissa from the exponent:

--- a/docs/cucumber/cucumber-expressions.mdx
+++ b/docs/cucumber/cucumber-expressions.mdx
@@ -64,7 +64,7 @@ the following built-in parameter types:
 | Parameter Type  | Description |
 | --------------- | ----------- |
 | `{int}`         | Matches integers, for example `71` or `-19`. Converts to a 32-bit signed integer if the platform supports it.|
-| `{float}`       | Matches floats, for example `3.6`, `.8` or `-9.2`. Converts to a 32 bit float if the platform supports it. |
+| `{float}`       | Matches floats, for example `3.6`, `.8`, `-9.2` or `1.5E+3` (see [scientific notation](#scientific-notation)). Converts to a 32 bit float if the platform supports it. |
 | `{word}`        | Matches words without whitespace, for example `banana` (but not `banana split`). |
 | `{string}`      | Matches single-quoted or double-quoted strings, for example `"banana split"` or `'banana split'` (but not `banana split`). Only the text between the quotes will be extracted. The quotes themselves are discarded. Empty pairs of quotes are valid and will be matched and passed to step code as empty strings. |
 | `{}` anonymous  | Matches anything (`/.*/`). |
@@ -74,6 +74,22 @@ the following built-in parameter types:
 | `{byte}`        | Matches the same as `{int}`, but converts to an 8 bit signed integer if the platform supports it. |
 | `{short}`       | Matches the same as `{int}`, but converts to a 16 bit signed integer if the platform supports it. |
 | `{long}`        | Matches the same as `{int}`, but converts to a 64 bit signed integer if the platform supports it. |
+
++### Scientific notation
+
+`{float}`, `{double}` and `{bigdecimal}` also match numbers written in scientific
+notation, using an uppercase `E` to separate the mantissa from the exponent:
+
+```
+I have 1.5E3 cucumbers in my belly
+I have 1.5E-3 cucumbers in my belly
+I have 1.5E+3 cucumbers in my belly
+```
+
+The exponent may optionally have a leading `+` or `-` sign. `1.5E3` and `1.5E+3`
+are equivalent, and both are parsed as `1500`.
+
+A lowercase `e` is **not** matched, so `1.5e3` will not be recognised as a float.
 
 ### Java
 


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

- Documented that {float}, {double}, and {bigdecimal} match scientific notation (e.g. 1.5E3, 1.5E-3, 1.5E+3).
- Added a note that the exponent may optionally include a leading + or - sign.
- Clarified that only an uppercase E is matched — lowercase e is not recognised.
- Updated the {float} row in the parameter types table to reference the new section.

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->
Closes #318. [cucumber/cucumber-expressions#445](https://github.com/cucumber/cucumber-expressions/pull/445) added general support for scientific notation floats (including positive exponents), but this behaviour wasn't documented anywhere.
### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :book: Documentation (improvements without changing code)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] My change doesn't require tests (docs-only change)

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
